### PR TITLE
fix: Use `0` instead of `7`

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,4 +6,4 @@ send_metrics = false
 workers_dev=false
 
 [triggers]
-crons = ["0 0 * * *", "0 20 * * 7"]
+crons = ["0 0 * * *", "0 20 * * 0"]


### PR DESCRIPTION
`7` is apparently [non-standard](https://crontab.guru/#0_20_*_*_7), so it will be modified to `0`.