### PR TITLE
fix: Allow Guthixian Cache notifications regardless of Wilderness Flash Events

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1,5 +1,12 @@
 import { setInterval } from "node:timers";
-import { Jewel, WildernessFlashEvent, guthixianCache, jewel, stock, wildernessFlashEvent } from "runescape";
+import {
+	Jewel,
+	WildernessFlashEvent,
+	guthixianCache as rGuthixianCache,
+	jewel,
+	stock,
+	wildernessFlashEvent as rWildernessFlashEvent,
+} from "runescape";
 import { request } from "undici";
 import { DISCORD_TOKEN, NOTIFICATION_CHANNEL_ID, Role } from "./constants.js";
 import { roleMention } from "./utility.js";
@@ -7,43 +14,53 @@ import { roleMention } from "./utility.js";
 if (!DISCORD_TOKEN) throw new Error("No Discord token provided.");
 if (!NOTIFICATION_CHANNEL_ID) throw new Error("No notification channel id provided.");
 
+function guthixianCache(contents: string[], timestamp: string) {
+	if (rGuthixianCache(1)) {
+		contents.push(`A ${roleMention(Role.GuthixianCache)} will open ${timestamp} with full rewards!`);
+	}
+
+	return contents;
+}
+
+function wildernessFlashEvent(contents: string[], timestamp: string) {
+	const nextWildernessFlashEvent = rWildernessFlashEvent(1);
+	let wildernessFlashEventContent = `${roleMention(Role.WildernessFlashEventSpecial)} `;
+
+	switch (nextWildernessFlashEvent) {
+		case WildernessFlashEvent.KingBlackDragonRampage:
+			wildernessFlashEventContent += "The King Black Dragon will rampage";
+			break;
+		case WildernessFlashEvent.InfernalStar:
+			wildernessFlashEventContent += "An infernal star will land";
+			break;
+		case WildernessFlashEvent.EvilBloodwoodTree:
+			wildernessFlashEventContent += "An evil bloodwood tree will grow";
+			break;
+		case WildernessFlashEvent.StrykeTheWyrm:
+			wildernessFlashEventContent += "The WildyWyrm will burrow to the surface";
+			break;
+		default:
+			return contents;
+	}
+
+	contents.push(`${wildernessFlashEventContent} ${timestamp}!`);
+	return contents;
+}
+
 setInterval(async () => {
 	const date = new Date();
 	const hours = date.getUTCHours();
 	const minutes = date.getUTCMinutes();
 	const seconds = date.getUTCSeconds();
-	const contents = [];
+	let contents: string[] = [];
 	if (seconds !== 0) return;
 
 	if (minutes === 55) {
 		// In 5 minutes.
 		const timestamp = `<t:${Math.floor((date.getTime() + 300_000) / 1_000)}:R>`;
 
-		if (guthixianCache(1)) {
-			contents.push(`A ${roleMention(Role.GuthixianCache)} will open ${timestamp} with full rewards!`);
-		}
-
-		const nextWildernessFlashEvent = wildernessFlashEvent(1);
-		let wildernessFlashEventContent = `${roleMention(Role.WildernessFlashEventSpecial)} `;
-
-		switch (nextWildernessFlashEvent) {
-			case WildernessFlashEvent.KingBlackDragonRampage:
-				wildernessFlashEventContent += "The King Black Dragon will rampage";
-				break;
-			case WildernessFlashEvent.InfernalStar:
-				wildernessFlashEventContent += "An infernal star will land";
-				break;
-			case WildernessFlashEvent.EvilBloodwoodTree:
-				wildernessFlashEventContent += "An evil bloodwood tree will grow";
-				break;
-			case WildernessFlashEvent.StrykeTheWyrm:
-				wildernessFlashEventContent += "The WildyWyrm will burrow to the surface";
-				break;
-			default:
-				return;
-		}
-
-		contents.push(`${wildernessFlashEventContent} ${timestamp}!`);
+		contents = guthixianCache(contents, timestamp);
+		contents = wildernessFlashEvent(contents, timestamp);
 	}
 
 	if (hours === 0 && minutes === 0) {


### PR DESCRIPTION
The default case here prevented Guthixian caches being sent:

https://github.com/Soulobby/Notifications/blob/f8aa4fbd7c64b11d6c8e99daa56451bc07c6eab1/source/index.ts#L29-L44